### PR TITLE
Adds cursor:pointer to menu toggle

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -41,6 +41,11 @@
     padding-bottom: 1.25rem;
 }
 
+.menu__toggle {
+    cursor: pointer;
+    outline: none;
+}
+
 .menu__toggle[open=""] {
     color: var(--pink);
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -43,7 +43,6 @@
 
 .menu__toggle {
     cursor: pointer;
-    outline: none;
 }
 
 .menu__toggle[open=""] {


### PR DESCRIPTION
On desktop, the cursor defaults to a text select icon. This fixes it so you get the indicator that it is clickable